### PR TITLE
add pyramid_chameleon dependency to setup.py

### DIFF
--- a/backend/setup.py
+++ b/backend/setup.py
@@ -31,6 +31,7 @@ setup(name=name,
         'pyramid_tm',
         'repoze.filesafe',
         'alembic',
+        'pyramid_chameleon'
     ],
     extras_require={
         'development': [


### PR DESCRIPTION
Pyramid 1.5a2 just got released, and it doesn't come with Chameleon anymore. We explicitly need to import pyramid_chameleon. see https://pypi.python.org/pypi/pyramid/1.5a2
