### PR TITLE
PEP-440 versions

### DIFF
--- a/backend/setup.py
+++ b/backend/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='foobar',
-    version_format='{tag}.dev{commitcount}+{gitsha}',
+    version_format='{tag}.{commitcount}+{gitsha}',
     url='https://github.com/pyfidelity/rest-seed',
     author='pyfidelity UG',
     author_email='mail@pyfidelity.com',

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -1,29 +1,8 @@
 from setuptools import setup, find_packages
-from subprocess import check_output
-from pkg_resources import get_distribution
 
 
-name = 'foobar'
-
-
-# update version from git
-try:
-    base = check_output('git describe --tags'.split()).strip()
-    full = check_output('git describe --tags --long --dirty'.split()).strip()
-except:
-    version = get_distribution(name).version
-else:
-    rest = full.replace(base, '', 1)
-    if rest.startswith('-0-') and not rest.endswith('-dirty'):
-        version = base
-    else:
-        version = full.replace('-', '.dev', 1)
-        version = version.replace('-', '+', 1)
-        version = version.replace('-', '.')
-
-
-setup(name=name,
-    version=version,
+setup(name='foobar',
+    version_format='{tag}.dev{commitcount}+{gitsha}',
     url='https://github.com/pyfidelity/rest-seed',
     author='pyfidelity UG',
     author_email='mail@pyfidelity.com',
@@ -47,6 +26,9 @@ setup(name=name,
         ('', ['alembic.ini'])
     ],
     zip_safe=False,
+    setup_requires=[
+        'setuptools-git-version'
+    ],
     install_requires=[
         'alembic',
         'bcrypt',

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup, find_packages
 from subprocess import check_output
+from pkg_resources import get_distribution
 
 
 name = 'foobar'
-version_file = 'backrest/version.txt'
 
 
 # update version from git
@@ -11,7 +11,7 @@ try:
     base = check_output('git describe --tags'.split()).strip()
     full = check_output('git describe --tags --long --dirty'.split()).strip()
 except:
-    pass
+    version = get_distribution(name).version
 else:
     rest = full.replace(base, '', 1)
     if rest.startswith('-0-') and not rest.endswith('-dirty'):
@@ -20,11 +20,10 @@ else:
         version = full.replace('-', '.dev', 1)
         version = version.replace('-', '+', 1)
         version = version.replace('-', '.')
-    open(version_file, 'wb').write(version)
 
 
 setup(name=name,
-    version=open(version_file, 'rb').read(),
+    version=version,
     url='https://github.com/pyfidelity/rest-seed',
     author='pyfidelity UG',
     author_email='mail@pyfidelity.com',
@@ -38,7 +37,6 @@ setup(name=name,
     packages=find_packages(),
     package_data={
         'backrest': [
-            'version.txt',
             'migrations/*.py',
             'migrations/versions/*.py',
             'templates/*.html',

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -17,7 +17,8 @@ else:
     if rest.startswith('-0-') and not rest.endswith('-dirty'):
         version = base
     else:
-        version = full.replace('-', '.', 1)
+        version = full.replace('-', '.dev', 1)
+        version = version.replace('-', '+', 1)
     open(version_file, 'wb').write(version)
 
 

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -19,6 +19,7 @@ else:
     else:
         version = full.replace('-', '.dev', 1)
         version = version.replace('-', '+', 1)
+        version = version.replace('-', '.')
     open(version_file, 'wb').write(version)
 
 

--- a/backend/tox.ini
+++ b/backend/tox.ini
@@ -4,6 +4,7 @@ envlist = py27
 [testenv]
 changedir = {envsitepackagesdir}
 deps =
+    setuptools >= 15.0
     pytest
     pytest-cov
     pytest-flakes

--- a/backend/tox.ini
+++ b/backend/tox.ini
@@ -4,7 +4,7 @@ envlist = py27
 [testenv]
 changedir = {envsitepackagesdir}
 deps =
-    setuptools >= 15.0
+    setuptools >= 8.0
     pytest
     pytest-cov
     pytest-flakes


### PR DESCRIPTION
Use [setuptools-git-version](https://pypi.python.org/pypi/setuptools-git-version/) to automatically create [PEP 440](https://www.python.org/dev/peps/pep-0440/)-compliant package versions.